### PR TITLE
Implements POST request relation's data.

### DIFF
--- a/src/feature/Task/utils/TaskUtils.ts
+++ b/src/feature/Task/utils/TaskUtils.ts
@@ -1,0 +1,25 @@
+import { useFetchData } from "../../../utils/fetchData";
+
+type RelationsData = {
+  data: Array<RelationData>;
+};
+
+type RelationData = {
+  type: string;
+  id: string;
+  attributes: {
+    name: string;
+  };
+};
+
+export function useGetRelationsData(baseUrl: string) {
+  const { data, isLoading } = useFetchData<RelationsData>(baseUrl);
+  if (data) {
+    const datas = data.data.map((item: RelationData) => ({
+      label: item.attributes.name,
+      value: item.id,
+    }));
+    return { datas }
+  }
+  return { isLoading }
+}


### PR DESCRIPTION
## 内容
参照フィールドを含んだPOSTできるJSONデータの用意。
リレーションデータをプルダウン（ReactSelect）で選択できるように対応。
ReactSelectで選択したデータをPOSTできるように対応。

## JSONデータサンプル
```
{
  data: {
    type: "node--task",
    attributes: {
      title: data.title,
      field_description: data.description,
    },
    relationships: {
      uid: {
        data: {
          type: "user--user",
          id: "570dfaca-8e38-4849-bb20-679c05c2488e",
        },
      },
      field_ref_project: {
        data: {
          type: "taxonomy_term--project",
          id: data.project.value,
        },
      },
    },
  },
}
```

## 関連
https://github.com/kazuya-u/React-PoC-Training/issues/30

