### PR TITLE
Oauthにて認証方法の確立

### DIFF
--- a/src/feature/AuthUser/LoginForm.tsx
+++ b/src/feature/AuthUser/LoginForm.tsx
@@ -1,6 +1,6 @@
 import { AuthUserForm, AuthUserInputField, AuthUserInputLabel, AuthUserInputWrapper, AuthUserSubmitButton, AuthUserErrorMessage } from "./StyledComponents";
-import { login } from "./utils/ApiUtils";
-import { setUserIdInLocalStorage } from "./utils/LocalStorageUtils";
+import { getToken, getUserUUID } from "./utils/ApiUtils";
+import { setAccessTokenLocalStorage, setUserIdInLocalStorage } from "./utils/LocalStorageUtils";
 import { toast } from "react-toastify";
 import { useForm } from "react-hook-form";
 
@@ -21,12 +21,14 @@ const LoginForm: React.FC = () => {
   
   const onSubmit = async (data: FormData) => {
     try {
-      const currentUserId = await login(data.user, data.password);
+      const authData = await getToken(data.user, data.password);
+      setAccessTokenLocalStorage(authData.access_token);
+      const currentUserId = await getUserUUID(data.user, data.password);
       setUserIdInLocalStorage(currentUserId);
       toast.done('ログインしました。');
       
     } catch (error) {
-        handleLoginError(error);
+      handleLoginError(error);
     }
   };
   const handleLoginError = (error: unknown) => {

--- a/src/feature/AuthUser/utils/ApiUtils.ts
+++ b/src/feature/AuthUser/utils/ApiUtils.ts
@@ -1,28 +1,55 @@
-export async function login(username: string, password: string): Promise<string> {
-  const endpoint = `${import.meta.env.VITE_LANDO_SITE_URL}/user/login?_format=json`;
+type TokenResponse = {
+  token_type: string;
+  expires_in: number;
+  access_token: string;
+  refresh_token: string;
+};
 
+export async function getToken(username: string, password: string): Promise<TokenResponse> {
+  const endpoint = `${import.meta.env.VITE_LANDO_SITE_URL}/oauth/token`;
+  const data = new URLSearchParams();
+  data.append('username', username);
+  data.append('password', password);
+  data.append('grant_type', 'password');
+  data.append('client_id', 'W9U9vcWpmPHjK-pI8ss_RnpOv1dEyTKgUv7WiZc_xP8');
+  data.append('client_secret', '@');
+  const headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'Accept': 'application/vnd.api+json'
+  };
   try {
-    const loginResponse = await fetch(endpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      },
-      body: JSON.stringify({
-        name: username,
-        pass: password
-      }),
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: headers,
+      body: data
     });
-    
-    if (loginResponse.ok) {
-      const loginData = await loginResponse.json();
-      console.log(loginData);
-      const currentUserId = loginData.current_user.uuid;
-      return currentUserId;
-    } else {
-      throw new Error('ログインに失敗しました。');
-    }
+    return await response.json() as TokenResponse;
   } catch (error) {
-    throw new Error('ネットワークエラー: ' + error);
+    throw new Error("ネットワークエラー: " + error);
+  }
+}
+
+export async function getUserUUID(username: string, password: string): Promise<string> {
+  const endpoint = `${import.meta.env.VITE_LANDO_SITE_URL}/user/login?_format=json`;
+  const headers = {
+    'Content-Type': 'application/vnd.api+json',
+    'Accept': 'application/vnd.api+json'
+  };
+  const data = {
+    name: username,
+    pass: password,
+  }
+  
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: headers,
+      body: JSON.stringify(data),
+    });
+    const responseData = await response.json();
+    const currentUserId = responseData.current_user.uuid;
+    return currentUserId;
+  } catch (error) {
+    throw new Error("ネットワークエラー: " + error);
   }
 }

--- a/src/feature/AuthUser/utils/LocalStorageUtils.ts
+++ b/src/feature/AuthUser/utils/LocalStorageUtils.ts
@@ -1,7 +1,16 @@
 const currentUserId = "currentUserId";
+const currentAccessToken = "access_token";
+
+export function setAccessTokenLocalStorage(accessToken: string): void {
+  localStorage.setItem(currentAccessToken, accessToken);
+}
 
 export function setUserIdInLocalStorage(userId: string): void {
   localStorage.setItem(currentUserId, userId);
+}
+
+export function getAccessTokenFromLocalStorage(): string | null {
+  return localStorage.getItem(currentAccessToken);
 }
 
 export function getUserIdFromLocalStorage(): string | null {

--- a/src/feature/Note/Patch/Index.tsx
+++ b/src/feature/Note/Patch/Index.tsx
@@ -1,12 +1,13 @@
-import { Controller, SubmitHandler, useForm } from "react-hook-form";
-import { NoteBodyDataType, NoteFormData, NoteRelatedData } from "../type/Index";
-import { GetOptions, patchData } from "../../..//feature/Task/utils/Utils";
-import { toast } from "react-toastify";
 import { Button, TextField } from "@mui/material";
-import Select from "react-select";
-import CreatableSelect from "react-select";
-import { useParams } from "react-router-dom";
+import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import { getAccessTokenFromLocalStorage } from "../../../feature/AuthUser/utils/LocalStorageUtils";
+import { GetOptions, patchData } from "../../..//feature/Task/utils/Utils";
+import { NoteBodyDataType, NoteFormData, NoteRelatedData } from "../type/Index";
+import { toast } from "react-toastify";
 import { useFetchData } from "../../../utils/fetchData";
+import { useParams } from "react-router-dom";
+import CreatableSelect from "react-select";
+import Select from "react-select";
 
 type DataType = {
   data: {
@@ -33,12 +34,11 @@ const Index: React.FC = () => {
   const { register, handleSubmit, control } = useForm();
 
   const onSubmit: SubmitHandler<NoteFormData> = async (data) => {
-    console.log(data);
     const endpoint = `${import.meta.env.VITE_LANDO_SITE_URL}/jsonapi/node/note/${pageParams.NoteId}`;
-
+    const accessToken = getAccessTokenFromLocalStorage();
     const headers = {
       "Content-Type": "application/vnd.api+json",
-      Accept: "application/vnd.api+json",
+      Authorization: `Bearer ${accessToken}`,
     };
     const bodyData: NoteBodyDataType = {
       data: {
@@ -95,17 +95,14 @@ const Index: React.FC = () => {
   if (!NoteData) {
     return <div>Loading...</div>;
   }
-  const projectData = NoteData.included.filter(
-    (item) => item.type === "taxonomy_term--project"
-  );
-  console.log(projectData);
+  // const projectData = NoteData.included.filter(
+  //   (item) => item.type === "taxonomy_term--project"
+  // );
+  // console.log(projectData);
   
-  const tagData = NoteData.included.filter(
-    (item) => item.type === "taxonomy_term--tags"
-  );
-  
-  
-  
+  // const tagData = NoteData.included.filter(
+  //   (item) => item.type === "taxonomy_term--tags"
+  // );
 
   return (
     <>

--- a/src/feature/Note/Post/Index.tsx
+++ b/src/feature/Note/Post/Index.tsx
@@ -1,5 +1,6 @@
 import { Button, TextField } from "@mui/material";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import { getAccessTokenFromLocalStorage } from "../../../feature/AuthUser/utils/LocalStorageUtils";
 import { GetOptions, postData } from "../../../feature/Task/utils/Utils";
 import { NoteBodyDataType, NoteFormData, NoteRelatedData } from "../type/Index";
 import { toast } from "react-toastify";
@@ -11,12 +12,11 @@ const Index: React.FC = () => {
   const { register, handleSubmit, control } = useForm();
 
   const onSubmit: SubmitHandler<NoteFormData> = async (data) => {
-    console.log(data);
-    const endpoint = `${import.meta.env.VITE_LANDO_SITE_URL}/jsonapi/node/note/`;
-    
+    const endpoint = `${import.meta.env.VITE_LANDO_SITE_URL}/jsonapi/node/note`;
+    const accessToken = getAccessTokenFromLocalStorage();
     const headers = {
       "Content-Type": "application/vnd.api+json",
-      Accept: "application/vnd.api+json",
+      Authorization: `Bearer ${accessToken}`,
     };
     const bodyData: NoteBodyDataType = {
       data: {
@@ -61,7 +61,6 @@ const Index: React.FC = () => {
       console.error("Nodeの投稿に失敗しました。", error);
       toast.error("Nodeの投稿に失敗しました。");
     }
-
   }
 
   return (

--- a/src/feature/Task/api/PostData.ts
+++ b/src/feature/Task/api/PostData.ts
@@ -2,12 +2,15 @@ import { postData } from "../utils/Utils";
 import { SubmitHandler } from "react-hook-form";
 import { TaskBodyDataType, TaskFormData, TaskRelatedData } from "../type/Index";
 import { toast } from "react-toastify";
+import { getAccessTokenFromLocalStorage } from "../../../feature/AuthUser/utils/LocalStorageUtils";
 
 export const onSubmitPostData: SubmitHandler<TaskFormData> = async (data) => {
   const endpoint = `${import.meta.env.VITE_LANDO_SITE_URL}/jsonapi/node/task`;
+  const accessToken = getAccessTokenFromLocalStorage();
   const headers = {
     "Content-Type": "application/vnd.api+json",
     Accept: "application/vnd.api+json",
+    "Authorization": `Bearer ${accessToken}`,
   };
   const bodyData: TaskBodyDataType = {
     data: {

--- a/src/utils/fetchData.ts
+++ b/src/utils/fetchData.ts
@@ -1,9 +1,14 @@
 import useSWR, { Fetcher } from "swr";
+import { getAccessTokenFromLocalStorage } from "../feature/AuthUser/utils/LocalStorageUtils";
 
 type baseUrlType = string;
 
 export function useFetchData<T>(baseUrl: baseUrlType) {
-  const fetcher: Fetcher<T> = (url: string) => fetch(url).then(r => r.json());
+  const accessToken = getAccessTokenFromLocalStorage();
+  const headers = {
+    "Authorization": `Bearer ${accessToken}`,
+  };
+  const fetcher: Fetcher<T> = (url: string) => fetch(url, { headers }).then(r => r.json());
   const { data, error } = useSWR(baseUrl, fetcher)
   return {
     data,


### PR DESCRIPTION
## Drupal
1. Simple OAuthをインストール。
2. /admin/config/people/simple_oauth にて公開鍵・秘密鍵を作成。（file-privete内にて作成）
3. Consumerの設定をする。
4. Client IDと、Roleを設定する。

## React
以下より、アクセストークンの取得
```
const endpoint = `${import.meta.env.VITE_LANDO_SITE_URL}/oauth/token`;
  const data = new URLSearchParams();
  data.append('username', username);
  data.append('password', password);
  data.append('grant_type', 'password');
  data.append('client_id', clientId);
  data.append('client_secret', '@');
  const headers = {
    'Content-Type': 'application/x-www-form-urlencoded',
    'Accept': 'application/vnd.api+json'
  };
  try {
    const response = await fetch(endpoint, {
      method: "POST",
      headers: headers,
      body: data
    });
    return await response.json() as TokenResponse;
  } catch (error) {
    throw new Error("ネットワークエラー: " + error);
  }
```

### 参考
[Drupal 8, Simple OAuth and simple REST](https://medium.com/@nikolay.r.borisov/drupal-8-simple-oauth-and-simple-rest-d2d90fa28334)