### PR TITLE
Implemented passing default values in props for React-Select component, which allows multiple selections.

### DIFF
--- a/src/feature/Task/Patch/Index.tsx
+++ b/src/feature/Task/Patch/Index.tsx
@@ -33,6 +33,22 @@ const TaskPatchForm: React.FC = () => {
   const extractStatusData = TaskData.included?.filter(
     (item) => item.type === "taxonomy_term--status"
   ) || [];
+  const extractTagData = TaskData.included?.filter(
+    (item) => item.type === "taxonomy_term--tags"
+  ) || [];
+  interface Tag {
+    value: string;
+    label: string;
+  }
+
+  const defaultTagsData: Tag[] = extractTagData.map((tagData) => ({
+    value: tagData.id,
+    label: tagData.attributes.name,
+  }));
+  if (!defaultTagsData) {
+    return;
+  }
+  
   
   return (
     <FormProvider {...methods}>
@@ -50,7 +66,7 @@ const TaskPatchForm: React.FC = () => {
           defaultValue={ExtractDefaultOptionData(extractStatusData[0])}
         />
         <TagSelect
-
+          defaultValue={defaultTagsData}
         />
         <TaskSubmit />
       </Form>

--- a/src/feature/Task/components/Input.tsx
+++ b/src/feature/Task/components/Input.tsx
@@ -16,6 +16,10 @@ interface SelectInputProps {
   };
 }
 
+interface MultipleSelectInputProps {
+  defaultValue?: SelectInputProps[];
+}
+
 export const TitleInput: React.FC<TextInputProps> = ({ defaultValue }) => {
   const { register } = useFormContext();
   return (
@@ -52,7 +56,7 @@ export const ProjectSelect: React.FC<SelectInputProps> = ({ defaultValue }) => {
 
 export const StatusSelect: React.FC<SelectInputProps> = ({ defaultValue }) => {
   const { control } = useFormContext();
-  
+
   return (
     <Controller
       control={control}
@@ -73,7 +77,9 @@ export const StatusSelect: React.FC<SelectInputProps> = ({ defaultValue }) => {
   )
 }
 
-export const TagSelect: React.FC = () => {
+export const TagSelect: React.FC<MultipleSelectInputProps> = ({ defaultValue }) => {
+  console.log(defaultValue);
+
   const { control } = useFormContext();
   return (
     <Controller
@@ -82,6 +88,7 @@ export const TagSelect: React.FC = () => {
       render={({ field }) => (
         <CreatableSelect
           {...field}
+          defaultValue={defaultValue}
           isClearable
           isMulti
           isSearchable
@@ -96,7 +103,7 @@ export const TagSelect: React.FC = () => {
 }
 
 export const DescriptionTextarea: React.FC<TextInputProps> = (
-  ({defaultValue}) => {
+  ({ defaultValue }) => {
     const { register } = useFormContext();
     return (
       <TextField


### PR DESCRIPTION
## 実装メモ
```
// Form側
const extractTagData = TaskData.included?.filter(
  (item) => item.type === "taxonomy_term--tags"
) || [];
interface Tag {
  value: string;
  label: string;
}

const defaultTagsData: Tag[] = extractTagData.map((tagData) => ({
  value: tagData.id,
  label: tagData.attributes.name,
}));
if (!defaultTagsData) {
  return;
}
```
```
// Component側
 <CreatableSelect
    {...field}
    defaultValue={defaultValue}
    isClearable
    isMulti
    isSearchable
/>
```