### PR TITLE
Implemented cache for pokemon-api.

### DIFF
--- a/src/feature/Navbar/Menu/Profile/UserIcon.tsx
+++ b/src/feature/Navbar/Menu/Profile/UserIcon.tsx
@@ -1,32 +1,19 @@
-import { useFetchData } from "../../../../utils/fetchData";
+import { BASE_API_URL } from "../../../../utils/EndPoint";
 import styled from "styled-components"
-
-interface PokeApiType {
-  sprites: {
-    front_default: string,
-  }
-}
 
 type Props = {
   iconNumber: string | undefined,
 }
 
 export const UserIcon: React.FC<Props> = ({ iconNumber }) => {
-  const POKE_URL = iconNumber ? `https://pokeapi.co/api/v2/pokemon/${iconNumber}/` : '';
-  const { data: IconData, error } = useFetchData<PokeApiType>(POKE_URL);
-  if (error) {
-    return (
-      <>
-        None...
-      </>
-    )
-  }
+  const POKE_URL = iconNumber ? `${BASE_API_URL}/sites/default/files/api/pokemon/${String(iconNumber).padStart(4, '0')}/front_default.png` : '';
+
   return (
     <StyledIcon>
       <StyledContainer>
         <StyledWrapper>
           <StyledInner>
-            {iconNumber ? <StyledImage src={IconData?.sprites.front_default} /> : ''}
+            <StyledImage src={POKE_URL} />
           </StyledInner>
         </StyledWrapper>
       </StyledContainer>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザーアイコンの取得方法を更新し、直接URLを構築するように変更しました。

- **リファクタ**
  - 不要なデータフェッチ関数を削除し、コードを簡素化しました。

- **スタイル**
  - ユーザーアイコンの条件付きレンダリングを削除し、ソース属性に直接URLを割り当てるように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->